### PR TITLE
Updated ScheduleTable.jsp, made links relative

### DIFF
--- a/content/src/main/content/jcr_root/apps/spademo/components/scheduletable/scheduletable.jsp
+++ b/content/src/main/content/jcr_root/apps/spademo/components/scheduletable/scheduletable.jsp
@@ -48,7 +48,7 @@
 </div>
 <script type="text/javascript">
     aemspa.scheduletable.init({
-      getPageContentUrl: 'http://localhost:4502/bin/mvc.do/scheduletable/getresult',
-      sortDataUrl: 'http://localhost:4502/bin/mvc.do/scheduletable/sortresult'
+      getPageContentUrl: '/bin/mvc.do/scheduletable/getresult',
+      sortDataUrl: '/bin/mvc.do/scheduletable/sortresult'
     });
 </script>


### PR DESCRIPTION
I was running my AEM instance on a different port than 4502, then i came across the problem that on ScheduleTable component, nothing was visible.
I tracked the problem that is it's because of the URL being hit for results is an absolute one(Port number being hardcoded in code). Making this one relative solved the problem.

I hope this PR helps
